### PR TITLE
[#51] Add player-based round end mechanics

### DIFF
--- a/assets/js/game_socket.js
+++ b/assets/js/game_socket.js
@@ -102,7 +102,7 @@ export function createMatch({matchId, timestamp}) {
 
 const handleEnterEvent = (channel, letter, inputs) => {
   return (event => {
-    if(event.key === "Enter" && validate(letter, inputs)) {
+    if(event.key === "Enter" && validateFields(letter, inputs)) {
       channel.push("player_finished", {letter})
     }
   })
@@ -111,7 +111,7 @@ const handleEnterEvent = (channel, letter, inputs) => {
 const isValid = (letter, input) =>
       input.value && input.value[0].toUpperCase() === letter.toUpperCase()
 
-const validate = (letter, inputs) =>
+const validateFields = (letter, inputs) =>
   Array.from(inputs).every(i => isValid(letter, i))
 
 const addEvents = (letter, inputs, channel) => {

--- a/lib/stop_my_hand_web/channels/match_channel.ex
+++ b/lib/stop_my_hand_web/channels/match_channel.ex
@@ -11,19 +11,23 @@ defmodule StopMyHandWeb.MatchChannel do
   @match_topic "match"
 
   @impl true
-  def join("match:"<>match_id, payload, socket) do
+  def join("match:"<>raw_match_id, payload, socket) do
     IO.inspect(socket.assigns.user)
     IO.inspect("channel joined")
+    match_id = String.to_integer(raw_match_id)
 
-    MatchDriver.player_joined(String.to_integer(match_id), socket.assigns.user)
+    MatchDriver.player_joined(match_id, socket.assigns.user)
 
     {:ok, assign(socket, :match_id, match_id)}
   end
 
-  def handle_in("round_finished", params, socket) do
-    IO.inspect("player_finished received")
-    # broadcast!(socket, "round_finished", params)
+  def handle_in("player_finished", params, socket) do
+    broadcast!(socket, "round_finished", params)
+    {:noreply, socket}
+  end
 
+  def handle_in("round_finished", params, socket) do
+    MatchDriver.round_finished(socket.assigns.match_id)
     {:noreply, socket}
   end
 end


### PR DESCRIPTION
Closes #51 

The player that completes filling the fields can trigger the end of round by pressing 'Enter' from any of the inputs. This updates the message handling to update the driver's state.