### PR TITLE
[#34] Add round timeout

### DIFF
--- a/assets/js/game_socket.js
+++ b/assets/js/game_socket.js
@@ -60,6 +60,7 @@ socket.connect()
 export function createMatch({matchId, timestamp}) {
   const offset = Math.abs(Date.now() - timestamp)
   let channel = socket.channel(`match:${matchId}`, {clockOffset: offset})
+  let currentLetter = null
   const gameFields = document.querySelectorAll('#round input[type="text"]')
   channel.join()
     .receive("ok", resp => { console.log("Joined successfully", resp) })
@@ -67,6 +68,7 @@ export function createMatch({matchId, timestamp}) {
   channel.on("game_start", ({ countdown, letter, round }) => {
     console.log(`GAME START - Countdown: ${countdown}. First letter: ${letter}`)
     let counter = countdown
+    currentLetter = letter
     const intervalId = setInterval(() => {
       counter--
       if(counter > 0) {
@@ -93,8 +95,9 @@ export function createMatch({matchId, timestamp}) {
       }
     }, 1000)
   })
-  channel.on("round_finished", ({letter}) => {
-    onRoundEnd(letter, gameFields, channel)
+  channel.on("round_finished", () => {
+    console.log(`round finished!: ${currentLetter}`)
+    onRoundEnd(currentLetter, gameFields, channel)
   })
 
   return channel

--- a/lib/stop_my_hand_web/channels/match_channel.ex
+++ b/lib/stop_my_hand_web/channels/match_channel.ex
@@ -21,11 +21,13 @@ defmodule StopMyHandWeb.MatchChannel do
     {:ok, assign(socket, :match_id, match_id)}
   end
 
+  # Player-triggered end of round (they filled all the fields)
   def handle_in("player_finished", params, socket) do
-    broadcast!(socket, "round_finished", params)
+    MatchDriver.round_finished(socket.assigns.match_id)
     {:noreply, socket}
   end
 
+  # Timeout-triggered en of round (no player finished filling the fields until the round timeout)
   def handle_in("round_finished", params, socket) do
     MatchDriver.round_finished(socket.assigns.match_id)
     {:noreply, socket}


### PR DESCRIPTION
Closes #34 

- When the round timeout expires without any player triggering the end of round by filling all the answers the round ends automatically for all players.
- If the players fill the answer and trigger the end of the game the timeout does nothing