### PR TITLE
[#69] Add basic notification system

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -2,6 +2,7 @@ let Hooks = {}
 
 Hooks.ConfirmInvite = {
   mounted() {
+    console.log("confirm invite")
     this.el.addEventListener("click", (event) => {
       event.preventDefault()
       const confirmed = confirm("Are you sure you want to send invite?")
@@ -62,6 +63,16 @@ Hooks.MatchHook = {
     window.addEventListener("match:onPlayerActivity", ({detail: payload}) => {
       console.log("player_activity")
       this.pushEvent("player_activity", payload)
+    })
+  }
+}
+
+Hooks.NotificationHover = {
+  mounted() {
+    console.log("NotificationHover mounted")
+    this.el.addEventListener("mouseenter", (e) => {
+      console.log(`The notification id: ${this.el.dataset.notificationId}`)
+      this.pushEvent("notification_read", { id: this.el.dataset.notificationId })
     })
   }
 }

--- a/lib/stop_my_hand/notification.ex
+++ b/lib/stop_my_hand/notification.ex
@@ -1,0 +1,75 @@
+defmodule StopMyHand.Notification do
+  @moduledoc """
+  The Notification context.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias StopMyHand.Repo
+  alias StopMyHandWeb.Endpoint
+  alias StopMyHand.Notification.Notification
+
+  @notification "notification"
+  @game_invite_title "Game invite!"
+
+  def notify_players(invitee_handle, match) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+    entries = Enum.map(match.players, fn player ->
+      metadata = %{
+        invitee: invitee_handle,
+        match_id: match.id
+      }
+      %{
+        title: @game_invite_title,
+        type: "game_invite",
+        status: "unread",
+        user_id: player.user_id,
+        metadata: metadata,
+        inserted_at: now,
+        updated_at: now
+      }
+    end)
+
+    case Repo.insert_all(Notification, entries, returning: true) do
+      {count, notifications} when count > 0 ->
+        {:ok, notifications}
+      {0, _} ->
+        Logger.warning("Failed to insert notifications for match #{match.id}")
+        {:error, "Failed to notify players"}
+    end
+  end
+
+  def broadcast_notifications(notifications) do
+    Enum.each(notifications, fn notification ->
+      Endpoint.broadcast("#{@notification}:#{notification.user_id}",
+        "game_invite",
+        notification.id
+      )
+    end)
+    :ok
+  end
+
+  def fetch_notifications(user_id) do
+    Notification
+    |> where(user_id: ^user_id)
+    |> order_by(desc: :inserted_at)
+    |> limit(5)
+    |> Repo.all()
+  end
+
+  def mark_as_read(notification_id) do
+    case Repo.get(Notification, notification_id) do
+      nil -> {:error, "Notification not found"}
+      notification ->
+        notification
+        |> Notification.changeset(%{status: "read"})
+        |> Repo.update()
+    end
+  end
+
+  defp insert_notification(attrs) do
+    %Notification{}
+    |> Notification.mark_read_changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/stop_my_hand/notification/notification.ex
+++ b/lib/stop_my_hand/notification/notification.ex
@@ -1,0 +1,27 @@
+defmodule StopMyHand.Notification.Notification do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "notifications" do
+    field :title, :string
+    field :status, :string
+    field :type, :string
+    field :user_id, :id
+    field :metadata, :map
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(notification, attrs) do
+    notification
+    |> cast(attrs, [:title, :status, :type, :metadata])
+    |> validate_required([:title, :status, :type, :metadata])
+  end
+
+  def mark_read_changeset(notification, attrs) do
+    notification
+    |> cast(attrs, [:status])
+    |> validate_inclusion(:status, ["unread", "read"])
+  end
+end

--- a/lib/stop_my_hand_web/components/notification.ex
+++ b/lib/stop_my_hand_web/components/notification.ex
@@ -1,0 +1,60 @@
+defmodule StopMyHandWeb.Notification do
+  use StopMyHandWeb, :live_component
+
+  alias StopMyHandWeb.Dropdown
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.live_component module={Dropdown} id="notifications">
+          <:button class="ml-auto">
+              <.icon name={bell_icon(@unread_count)} />
+              <%= if @unread_count > 0 do %>
+                  <span class="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full h-3 w-3 flex items-center justify-center">
+                  <%= @unread_count %>
+                  </span>
+              <% end %>
+          </:button>
+          <%= for {dom_id, notification} <- @notifications do %>
+              <.dropdown_item>
+                  <%= notification(notification) %>
+              </.dropdown_item>
+          <% end %>
+      </.live_component>
+    </div>
+    """
+  end
+
+  def handle_event("notification_read", %{"id" => notification_id}, socket) do
+    send self(), {:mark_notification_read, notification_id}
+  end
+
+  defp notification(notification) do
+    case notification.type do
+      "game_invite" -> game_notification(notification)
+      _ -> generic_notification(notification)
+    end
+  end
+
+  defp game_notification(assigns) do
+    ~H"""
+    <div id={"notification-#{@id}"} phx-hook="NotificationHover" data-notification-id={@id} class={[@status == "read" && "opacity-50"]}>
+      <title>@title</title>
+      <section>
+        <p>
+          <strong><%= @metadata["invitee"] %></strong> invites you to <a href={~p"/lobby/#{@metadata["match_id"]}"}>a match!</a>
+        </p>
+      </section>
+    </div>
+    """
+  end
+
+  defp generic_notification(assigns) do
+    ~H"""
+    <title>@title</title>
+    """
+  end
+
+  defp bell_icon(unread_count) when unread_count > 0, do: "hero-bell"
+  defp bell_icon(unread_count), do: "hero-bell-slash"
+end

--- a/lib/stop_my_hand_web/live/frienship/search.ex
+++ b/lib/stop_my_hand_web/live/frienship/search.ex
@@ -20,7 +20,7 @@ defmodule StopMyHandWeb.Friendship.Search do
           ]}>
             <%= if !Enum.empty?(results) do %>
               <%= for result <- results do %>
-                <.result_item user={result} myself={@myself}/>
+                <.result_item user={result}/>
               <% end %>
             <% else %>
               No results

--- a/priv/repo/migrations/20260102201358_create_notifications.exs
+++ b/priv/repo/migrations/20260102201358_create_notifications.exs
@@ -1,0 +1,17 @@
+defmodule StopMyHand.Repo.Migrations.CreateNotifications do
+  use Ecto.Migration
+
+  def change do
+    create table(:notifications) do
+      add :title, :string
+      add :type, :string
+      add :status, :string
+      add :user_id, references(:users, on_delete: :nothing)
+      add :metadata, :map, default: %{}
+
+      timestamps()
+    end
+
+    create index(:notifications, [:user_id])
+  end
+end


### PR DESCRIPTION
Closes #69 

- Add notification migration
- Add Notification context It's in charge of creating the notifications and broadcasting them accordingly
- Add notification view
  - A dropdown from a bell icon with a red counter badge.
  - Notifications are marked as read on hover
  - Read notifications have higher opacity
  - Game invites redirect to lobby for the match
- Lobby redirection If the match is already ongoing we redirect to the match view on mount. We figure that out by checking the Registry with the match id