### PR TITLE
[#81] Configure video calling on Match creation

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -40,8 +40,8 @@ liveSocket.connect()
 // >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket
 
-window.addEventListener("phx:connect_match", async ({detail: { match_id, current_user_id }}) => {
-  await createMatch({matchId: match_id, currentUserId: current_user_id})
+window.addEventListener("phx:connect_match", async ({detail: { match_id, current_user_id, video_enabled }}) => {
+  await createMatch({matchId: match_id, currentUserId: current_user_id, videoEnabled: video_enabled})
 })
 
 // WARN: A listener suggested in: https://elixirforum.com/t/how-to-close-modal/54331/7

--- a/assets/js/game/match_channel.js
+++ b/assets/js/game/match_channel.js
@@ -40,8 +40,11 @@ export const createAndJoinMatchChannel = (socket, matchId, conferenceManager) =>
   channel.on("show_scores", () => window.dispatchEvent(new CustomEvent("match:score")))
   channel.on("player_activity", (params) => window.dispatchEvent(new CustomEvent("match:onPlayerActivity", { detail: params })))
   channel.on("game_finished", () => window.location = "/")
-  channel.on("peer_joined", ({ user_id }) => conferenceManager.handlePeerJoined(user_id))
-  channel.on("peer_left", ({ user_id }) => conferenceManager.removePeer(user_id))
+
+  if(conferenceManager) {
+    channel.on("peer_joined", ({ user_id }) => conferenceManager.handlePeerJoined(user_id))
+    channel.on("peer_left", ({ user_id }) => conferenceManager.removePeer(user_id))
+  }
 
   channel.join()
     .receive("ok", resp => console.log("Joined match channel", resp))

--- a/assets/js/game/socket.js
+++ b/assets/js/game/socket.js
@@ -2,37 +2,50 @@
 // you uncomment its entry in "assets/js/app.js".
 
 // Bring in Phoenix matchChannels client library:
-import {Socket} from "phoenix"
-import {ConferenceManager} from "./conference/conference_manager"
+import { Socket } from "phoenix"
+import { ConferenceManager } from "./conference/conference_manager"
 import { createUserChannel, joinUserChannel } from "./conference/user_channel"
 import { createAndJoinMatchChannel } from "./match_channel"
 import { setupMediaControls, onRemoteTrack } from "./conference/media_controls"
 
 // And connect to the path in "lib/stop_my_hand_web/endpoint.ex". We pass the
 // token for authentication. Read below how it should be used.
-let socket = new Socket("/game", {params: {token: window.userToken}})
+let socket = new Socket("/game", { params: { token: window.userToken } })
 
-export async function createMatch({matchId, currentUserId}) {
-  if(!socket.isConnected()) {
+export async function createMatch({ matchId, currentUserId, videoEnabled }) {
+  if (!socket.isConnected()) {
     socket.connect()
   }
 
-  const userChannel = createUserChannel(socket, currentUserId)
+  let conferenceManager
+  let userChannel
 
-  const conferenceManager = new ConferenceManager(
-    userChannel,
-    currentUserId,
-    onRemoteTrack,
-    (peerId, state) => {
-      console.log(`Peer ${peerId} connection state: ${state}`)
-    }
-  );
+  console.log(videoEnabled);
 
-  await setupMediaControls(conferenceManager)
+  if (videoEnabled) {
+    userChannel = createUserChannel(socket, currentUserId)
 
-  const matchChannel = createAndJoinMatchChannel(socket, matchId, conferenceManager)
+    conferenceManager = new ConferenceManager(
+      userChannel,
+      currentUserId,
+      onRemoteTrack,
+      (peerId, state) => {
+        console.log(`Peer ${peerId} connection state: ${state}`)
+      },
+    )
 
-  joinUserChannel(userChannel, conferenceManager)
+    await setupMediaControls(conferenceManager)
+  }
+
+  const matchChannel = createAndJoinMatchChannel(
+    socket,
+    matchId,
+    conferenceManager,
+  )
+
+  if (videoEnabled) {
+    joinUserChannel(userChannel, conferenceManager)
+  }
 }
 
 export default socket

--- a/lib/stop_my_hand/game/match.ex
+++ b/lib/stop_my_hand/game/match.ex
@@ -5,6 +5,7 @@ defmodule StopMyHand.Game.Match do
   alias StopMyHand.Accounts.User
 
   schema "matches" do
+    field :video_enabled, :boolean
 
     belongs_to :creator, User
     has_many :players, Player, foreign_key: :match_id
@@ -15,7 +16,7 @@ defmodule StopMyHand.Game.Match do
   @doc false
   def changeset(match, attrs) do
     match
-    |> cast(attrs, [:creator_id])
+    |> cast(attrs, [:creator_id, :video_enabled])
     |> cast_assoc(:players)
     |> validate_required([:creator_id])
   end

--- a/lib/stop_my_hand_web/live/game/create_match.ex
+++ b/lib/stop_my_hand_web/live/game/create_match.ex
@@ -27,6 +27,7 @@ defmodule StopMyHandWeb.Game.CreateMatch do
         </.async_result>
         <.simple_form for={to_form(@changeset)} :let={f} phx-submit="save" phx-target={@myself} id="match">
           <.input type="hidden" field={f[:creator_id]} value={@current_user.id} />
+          <.input type="checkbox" field={f[:video_enabled]} label="Enable video?" />
           <.inputs_for :let={players_form} field={f[:players]} as={:players}>
             <.input type="hidden" field={players_form[:user_id]} />
           </.inputs_for>

--- a/lib/stop_my_hand_web/live/game/match.ex
+++ b/lib/stop_my_hand_web/live/game/match.ex
@@ -15,7 +15,7 @@ defmodule StopMyHandWeb.Game.Match do
   def render(assigns) do
     ~H"""
     <div class="flex flex-col gap-5 items-center justify-center">
-      <.player_view source={:local} peer_id={@current_user.id} />
+      <.player_view source={:local} peer_id={@current_user.id} video_enabled={@match.video_enabled}/>
       <.round_info round_number={@round_number} score={Map.get(@score, @current_user.id, 0)} current_letter={Map.get(assigns, :current_letter, "")} />
       <div id="game" class={["flex flex-col gap-5 items-center justify-center"]} phx-hook="MatchHook">
         <.simple_form :let={f} for={to_form(Map.from_struct(@round))} id="round">
@@ -27,7 +27,7 @@ defmodule StopMyHandWeb.Game.Match do
           <%= for {player_id, data} <- @player_data, player_id != @current_user.id do %>
             <div class="flex flex-col gap-3">
               <div class="flex gap-3 items-center text-4xl">
-                <.player_view source={:remote} peer_id={player_id} />
+                <.player_view source={:remote} peer_id={player_id} video_enabled={@match.video_enabled} />
                 <h2>{data.handle}</h2>
                 <div class="font-bold">
                   {Map.get(@score, player_id, 0)}
@@ -45,6 +45,7 @@ defmodule StopMyHandWeb.Game.Match do
 
   def mount(params, _session, socket) do
     match = Game.get_match(params["match_id"])
+    IO.inspect(match.video_enabled, label: "Video has been enabled")
 
     base_assigns = fn player_data ->
       %{
@@ -65,7 +66,8 @@ defmodule StopMyHandWeb.Game.Match do
     {:ok, socket
      |> assign(final_assigns)
      |> assign(:mode, game_mode(game_status))
-     |> push_event("connect_match", %{match_id: match.id, current_user_id: socket.assigns.current_user.id})
+     |> push_event("connect_match", %{match_id: match.id, current_user_id:
+        socket.assigns.current_user.id, video_enabled: match.video_enabled})
     }
   end
 

--- a/lib/stop_my_hand_web/live/game/match/player_view.ex
+++ b/lib/stop_my_hand_web/live/game/match/player_view.ex
@@ -17,17 +17,18 @@ defmodule StopMyHandWeb.Game.Match.PlayerView do
   has videocalling enabled.
   """
 
+  attr :video_enabled, :boolean, doc: "Whether this view should contain video conferencing controls"
   attr :source, :atom, values: [:local, :remote], doc: "where does the view come from", required: true
   attr :peer_id, :integer, required: true
 
   def player_view(assigns) do
     ~H"""
     <div id={"player-view-#{@peer_id}"} phx-update="ignore" class="relative w-24 h-24 bg-gray-200 flex items-center justify-center text-gray-600 text-sm font-medium rounded-lg">
-      <video autoplay class="w-24 h-24 object-cover" id={video_id(@source, @peer_id)} />
+      <video :if={@video_enabled} autoplay class="w-24 h-24 object-cover" id={video_id(@source, @peer_id)} />
       <button :if={@source == :local} id="local-mic" class="absolute bottom-2 left-2 p-1.5 bg-black bg-opacity-50 rounded-full hover:bg-opacity-70">
           <i class="hero-microphone w-4 h-4 text-green-500"></i>
       </button>
-      <button :if={@source == :local} id="local-camera" class="absolute bottom-2 right-2 p-1.5 bg-black bg-opacity-50 rounded-full hover:bg-opacity-70">
+      <button :if={@source == :local && @video_enabled} id="local-camera" class="absolute bottom-2 right-2 p-1.5 bg-black bg-opacity-50 rounded-full hover:bg-opacity-70">
           <i class="hero-video-camera-slash w-4 h-4 text-white"></i>
       </button>
     </div>

--- a/priv/repo/migrations/20260327195243_add_video_enabled_to_match.exs
+++ b/priv/repo/migrations/20260327195243_add_video_enabled_to_match.exs
@@ -1,0 +1,11 @@
+defmodule StopMyHand.Repo.Migrations.AddVideoEnabledToMatch do
+  use Ecto.Migration
+
+  def change do
+    alter table("matches") do
+      add :video_enabled, :boolean, default: false, null: false
+    end
+
+    create index("matches", [:video_enabled], where: "video_enabled = true", name: :video_enabled_idx)
+  end
+end


### PR DESCRIPTION
Closes #81 

We default to not enabling the video calling feature unless the user requests it for a match.

- Add migration to add `video_enabled` field to the `Match` schema
- Add checkbox to the Match creation form to enable/disable the value
- Include the value in the event that signals the JS channel socket to exclude logic related to videocalling
- Remove video calling controls from player view when disabled