### PR TITLE
[#86] Add match e2e tests round

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -59,10 +59,12 @@ config :logger, :console,
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
 
+# Set the default scheduler
+# Test environment overrides this to use a mock via Mox
+config :stop_my_hand, scheduler: StopMyHand.Scheduler
+config :stop_my_hand, :timeouts, review: 10_000
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{config_env()}.exs"
 
-# Set the default scheduler
-# Test environment overrides this to use a mock via Mox
-config :stop_my_hand, scheduler: StopMyHand.Scheduler

--- a/config/test.exs
+++ b/config/test.exs
@@ -42,3 +42,4 @@ config :logger, level: :warning
 # Initialize plugs at runtime for faster test compilation
 config :phoenix, :plug_init_mode, :runtime
 config :stop_my_hand, sql_sandbox: true
+config :stop_my_hand, :timeouts, review: 1_000

--- a/e2e-tests/match.spec.js
+++ b/e2e-tests/match.spec.js
@@ -10,37 +10,83 @@ test.afterEach(async ({ page }) => {
   await teardownSandbox(page);
 });
 
-test("player gets other player's activity", async ({ browser }) => {
-  const context1 = await browser.newContext();
-  const page1 = await context1.newPage();
-  await setupSandbox(page1);
-  const { match_id, creator, players } = await setupScenario(
-    page1,
-    "match_lobby",
-  );
-  await login(page1, creator.id);
-  await page1.goto(`/lobby/${match_id}`);
+test.describe("match round", () => {
+  let letter;
+  let page1;
+  let page2;
+  let creatorPlayer;
+  let allPlayers;
 
-  const context2 = await browser.newContext();
-  const page2 = await context2.newPage();
-  await setupSandbox(page2);
-  await login(page2, players[0].id);
-  await page2.goto(`/lobby/${match_id}`);
-  await page2.waitForURL(`/lobby/${match_id}`);
+  test("player can review a player's answers", async ({browser}) => {
+    const context1 = await browser.newContext();
+    page1 = await context1.newPage();
+    const context2 = await browser.newContext();
+    page2 = await context2.newPage();
+    await setupSandbox([page1, page2]);
+    const { match_id, creator, players } = await setupScenario(
+      page1,
+      "match_lobby",
+    );
 
-  const btn = page1.getByRole("button", { name: "Play" });
-  await expect(btn).toBeEnabled({ timeout: 15000 });
-  await btn.click();
-  await page1.waitForURL(`/match/${match_id}`);
-  await page2.waitForURL(`/match/${match_id}`);
+    creatorPlayer = creator;
+    allPlayers = players;
 
-  await expect(page1.locator("#letter")).not.toBeEmpty();
-  const letter = await page1.locator("#letter").textContent();
-  await expect(page1.getByLabel("Name", { exact: true })).toBeEnabled();
-  await page1.getByLabel("Name", { exact: true }).fill(`${letter}xx`);
-  await page1.getByLabel("Last Name", { exact: true }).focus();
+    await login(page1, creator.id);
+    await page1.goto(`/lobby/${match_id}`);
+    await page1.waitForURL(`/lobby/${match_id}`);
+    await login(page2, players[0].id);
+    await page2.goto(`/lobby/${match_id}`);
+    await page2.waitForURL(`/lobby/${match_id}`);
 
-  await expect(page2.getByTestId(`name-activity-${creator.id}`)).toHaveText(
-    letter.repeat(3),
-  );
+    const btn = page1.getByRole("button", { name: "Play" });
+    await expect(btn).toBeEnabled({ timeout: 15000 });
+    await btn.click();
+    await page1.waitForURL(`/match/${match_id}`);
+    await page2.waitForURL(`/match/${match_id}`);
+
+    await expect(page1.locator("#letter")).not.toBeEmpty({timeout: 10000});
+    letter = await page1.locator("#letter").textContent();
+    await expect(page1.getByLabel("Name", { exact: true })).toBeEnabled();
+    const categories = [
+      "name",
+      "last_name",
+      "city",
+      "color",
+      "animal",
+      "thing",
+    ];
+
+    const fields = await page1.locator('input[type="text"]').all();
+    const fields2 = await page2.locator('input[type="text"]').all();
+
+    for (const input of fields) {
+      await input.fill(letter.repeat(3));
+    }
+
+    for (const input of fields2) {
+      await input.fill(letter.repeat(3));
+    }
+
+    await fields.at(-1).press("Enter");
+
+    for (const category of categories.slice(0, -1)) {
+      await page2
+        .getByTestId(`accept-button-${category}`)
+        .click();
+      await page1
+        .getByTestId(`accept-button-${category}`)
+        .click();
+    }
+
+    await page2.getByTestId("reject-button-thing").click();
+    await page1.getByTestId("reject-button-thing").click();
+
+    for (const category of categories.slice(0, -1)) {
+      await expect(page2.getByTestId(`score-${category}-${allPlayers[0].id}`)).toHaveText("50");
+      await expect(page1.getByTestId(`score-${category}-${creatorPlayer.id}`)).toHaveText("50");
+    }
+
+    await expect(page2.getByTestId(`score-${categories.at(-1)}-${allPlayers[0].id}`)).toHaveText("0");
+    await expect(page1.getByTestId(`score-${categories.at(-1)}-${creatorPlayer.id}`)).toHaveText("0");
+  });
 });

--- a/e2e-tests/support/setup_scenario.js
+++ b/e2e-tests/support/setup_scenario.js
@@ -1,28 +1,33 @@
-export async function setupSandbox(page) {
-  const res = await page.request.post("http://127.0.0.1:4002/sandbox");
-  const { token } = await res.text();
-  await page.setExtraHTTPHeaders({ "user-agent": token });
+export async function setupSandbox(pages) {
+  const res = await pages[0].request.post("http://127.0.0.1:4002/sandbox");
+  const token = await res.text();
+  await Promise.all(
+    pages.map((p) => p.setExtraHTTPHeaders({ "user-agent": token })),
+  );
 }
 
 export async function setupScenario(page, scenario) {
   const res = await page.request.post("http://127.0.0.1:4002/test/setup", {
-    data: { scenario }
+    data: { scenario },
   });
   return await res.json();
 }
 
 export async function login(page, user_id) {
   const res = await page.request.post("http://127.0.0.1:4002/test/login", {
-    data: { user_id }
+    data: { user_id },
   });
+
   const cookieHeader = res.headers()["set-cookie"];
   const value = cookieHeader.split(";")[0].split("=").slice(1).join("=");
-  await page.context().addCookies([{
-    name: "_stop_my_hand_key",
-    value,
-    domain: "localhost",
-    path: "/"
-  }]);
+  await page.context().addCookies([
+    {
+      name: "_stop_my_hand_key",
+      value,
+      domain: "localhost",
+      path: "/",
+    },
+  ]);
 }
 
 export async function teardownSandbox(page) {

--- a/lib/stop_my_hand/match_driver.ex
+++ b/lib/stop_my_hand/match_driver.ex
@@ -10,7 +10,7 @@ defmodule StopMyHand.MatchDriver do
   @quorum_timeout 45_000
   @game_start_timeout 1_000
   @answers_timeout 10_000
-  @base_review_timeout 10_000
+  @base_review_timeout Application.compile_env(:stop_my_hand, [:timeouts, :review])
   @next_round_timeout 5_000
   @match_topic "match"
   @countdown 3

--- a/lib/stop_my_hand_web/live/game/match.ex
+++ b/lib/stop_my_hand_web/live/game/match.ex
@@ -20,7 +20,7 @@ defmodule StopMyHandWeb.Game.Match do
       <div id="game" class={["flex flex-col gap-5 items-center justify-center"]} phx-hook="MatchHook">
         <.simple_form :let={f} for={to_form(Map.from_struct(@round))} id="round">
           <div class="flex gap-3">
-            <.scored_field :for={category <- @categories} form={f} category={category} score={get_in(@player_data, [@current_user.id, :answers, category, :result])} />
+            <.scored_field :for={category <- @categories} form={f} category={category} score={get_in(@player_data, [@current_user.id, :answers, category, :result])}  player_id={@current_user.id}/>
           </div>
         </.simple_form>
         <div class="flex flex-col gap-3">
@@ -150,7 +150,7 @@ defmodule StopMyHandWeb.Game.Match do
   defp scored_field(assigns) do
     ~H"""
     <div class="flex flex-col items-center justify-center">
-      <.score :if={assigns.score} result={@score} />
+      <.score :if={assigns.score} result={@score} category={@category} player_id={@player_id}/>
       <div>
         <.input field={@form[@category]} label={translate_category(@category)} data-category={Atom.to_string(@category)}/>
       </div>

--- a/lib/stop_my_hand_web/live/game/match/player_view.ex
+++ b/lib/stop_my_hand_web/live/game/match/player_view.ex
@@ -84,7 +84,9 @@ defmodule StopMyHandWeb.Game.Match.PlayerView do
       <div :for={category <- @categories} class="flex gap-2 items-center justify-center">
         <span class="font-bold text-xl">{translate_category(category)}:</span>
         <div class="flex flex-col items-center justify-center">
-          <.score :if={get_in(@player_data, [:answers, category, :result])} result={get_in(@player_data, [:answers, category, :result])} />
+          <.score :if={get_in(@player_data, [:answers, category, :result])}
+          result={get_in(@player_data, [:answers, category, :result])}
+          category={category} player_id={@player_id}/>
           <%= if @player_data.answers[category].value == "" do %>
             <span>--</span>
           <% else %>
@@ -96,13 +98,15 @@ defmodule StopMyHandWeb.Game.Match.PlayerView do
         <.button
           :if={category_submitted?(@current_category, category, @player_data.answers[category].value)}
           class={review_button_class(@player_data.answers[category].reviews[@current_user_id], :accepted)}
-          phx-click="review_answer" phx-value-playerid={@player_id} phx-value-result="accepted">
+          phx-click="review_answer" phx-value-playerid={@player_id} phx-value-result="accepted"
+          data-testid={"accept-button-#{@current_category}"}>
           <.icon name="hero-check" />
         </.button>
         <.button
           :if={category_submitted?(@current_category, category, @player_data.answers[category].value)}
           class={review_button_class(@player_data.answers[category].reviews[@current_user_id], :rejected)}
-          phx-click="review_answer" phx-value-playerid={@player_id} phx-value-result="rejected">
+          phx-click="review_answer" phx-value-playerid={@player_id} phx-value-result="rejected"
+          data-testid={"reject-button-#{@current_category}"}>
           <.icon name="hero-x-mark" />
         </.button>
       </div>
@@ -111,11 +115,14 @@ defmodule StopMyHandWeb.Game.Match.PlayerView do
   end
 
   attr :result, :map, required: true
+  attr :category, :string, required: true
+  attr :player_id, :integer, required: true
 
   def score(assigns) do
     ~H"""
-      <div class={[points_class(@result.reason), "font-bold"]}>
-        {@result.points}
+      <div class={[points_class(@result.reason), "font-bold"]}
+        data-testid={"score-#{@category}-#{@player_id}"}>
+        {ceil(@result.points)}
       </div>
     """
   end

--- a/test/stop_my_hand/match_driver_test.exs
+++ b/test/stop_my_hand/match_driver_test.exs
@@ -304,7 +304,7 @@ the reported answers only", context do
       refute payload.letter == current_letter
     end
 
-    test "review timeout is the 10 seconds per active player" do
+    test "review timeout is proportional to number of active player" do
       match = create_match()
       players = [match.creator|(for player <- match.players, do: player.user)]
 
@@ -327,7 +327,7 @@ the reported answers only", context do
       send(pid, :answers_timeout)
 
       expect(StopMyHand.Scheduler.Mock, :send_after, fn _pid, {:review_timeout, _idx}, timeout ->
-        assert timeout == 30_000
+        assert ceil(timeout / Application.get_env(:stop_my_hand, :timeouts)[:review]) == 3
         :ok
       end)
 


### PR DESCRIPTION
Closes #86 

Adds e2e tests to cover a complete round using two browsers with two players:

- Joining
- Filling answers
- Triggering end of round
- Voting in the review phase
- Showing scores