### PR TITLE
[#94] Add custom metrics to LiveDashboard

### DIFF
--- a/lib/stop_my_hand/accounts.ex
+++ b/lib/stop_my_hand/accounts.ex
@@ -350,4 +350,9 @@ defmodule StopMyHand.Accounts do
       {:error, :user, changeset, _} -> {:error, changeset}
     end
   end
+
+  def get_active_users_count() do
+    query = from u in "users", where: not is_nil(u.confirmed_at), select: u.id
+    Repo.aggregate(query, :count)
+  end
 end

--- a/lib/stop_my_hand/game.ex
+++ b/lib/stop_my_hand/game.ex
@@ -45,4 +45,8 @@ defmodule StopMyHand.Game do
     |> Match.changeset(attrs)
     |> Repo.insert()
   end
+
+  def get_created_match_count() do
+    Repo.aggregate(Match, :count)
+  end
 end

--- a/lib/stop_my_hand_web/live/dashboard/stats_page.ex
+++ b/lib/stop_my_hand_web/live/dashboard/stats_page.ex
@@ -1,0 +1,30 @@
+defmodule StopMyHandWeb.Dashboard.StatsPage do
+  use Phoenix.LiveDashboard.PageBuilder
+
+  import StopMyHand.Accounts, only: [get_active_users_count: 0]
+  import StopMyHand.Game, only: [get_created_match_count: 0]
+
+  @impl true
+  def menu_link(_, _) do
+    {:ok, "Stats"}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <.card_title title="Aggregates"/>
+    <.row>
+      <:col>
+        <.card inner_title="# Users" hint="Number of active users">
+          {get_active_users_count()}
+        </.card>
+      </:col>
+      <:col>
+        <.card inner_title="# Games" hint="Number of games created">
+          {get_created_match_count()}
+        </.card>
+      </:col>
+    </.row>
+    """
+  end
+end

--- a/lib/stop_my_hand_web/router.ex
+++ b/lib/stop_my_hand_web/router.ex
@@ -49,7 +49,11 @@ defmodule StopMyHandWeb.Router do
     scope "/dev" do
       pipe_through :browser
 
-      live_dashboard "/dashboard", metrics: StopMyHandWeb.Telemetry
+      live_dashboard "/dashboard",
+        metrics: StopMyHandWeb.Telemetry,
+        additional_pages: [
+          route_name: StopMyHandWeb.Dashboard.StatsPage
+        ]
       forward "/mailbox", Plug.Swoosh.MailboxPreview
     end
   end


### PR DESCRIPTION
Closes #94 

Add two custom metrics to the stock `LiveDashboard`:

- Total active users
- Total games created