### PR TITLE
Fix metrics header check

### DIFF
--- a/lib/stop_my_hand/plugs/secure_metrics_endpoint.ex
+++ b/lib/stop_my_hand/plugs/secure_metrics_endpoint.ex
@@ -5,6 +5,6 @@ defmodule StopMyHand.SecureMetricsEndpoint do
   def call(conn, env_var) do
     auth_header = Plug.Conn.get_req_header(conn, "authorization")
 
-    System.get_env(env_var) == auth_header
+    List.first(auth_header) == "Bearer #{System.get_env(env_var)}"
   end
 end


### PR DESCRIPTION
Get the header from the result list and include `Bearer` in the check via interpolation.